### PR TITLE
raise HTTPError instead of returning an empty list

### DIFF
--- a/pylibgen/pylibgen.py
+++ b/pylibgen/pylibgen.py
@@ -65,6 +65,8 @@ class Library(object):
             'ids': ','.join(ids),
             'fields': ','.join(fields),
         }).json()
+        if not res:
+            raise requests.HTTPError(400)
         return res if len(res) > 1 else res[0]
 
     def get_download_url(self, md5, enable_ads=False):

--- a/pylibgen/pylibgen.py
+++ b/pylibgen/pylibgen.py
@@ -66,6 +66,7 @@ class Library(object):
             'fields': ','.join(fields),
         }).json()
         if not res:
+            # https://github.com/JoshuaRLi/pylibgen/pull/3
             raise requests.HTTPError(400)
         return res if len(res) > 1 else res[0]
 


### PR DESCRIPTION
When making an isbn search for a book, sometimes an empty list is returned. e.g., when I want to download "The God Delusion" using its isbn ('9780618680009') I get an empty list. This should raise an HTTPError instead, so that is behaves similar to the libgen server, which usually returns a 400 when no matches are found. Raising a 400 error will simplify programs that use your package (such as the program I'm developing).