### PR TITLE
changed to assert to accomadate mismatched order also fixed a small bug

### DIFF
--- a/pylibgen/pylibgen.py
+++ b/pylibgen/pylibgen.py
@@ -132,7 +132,7 @@ class Library(object):
         if "id" not in fields:
             fields.append("id")
         if "*" in fields:
-            fields = ["*"]
+            fields = list(**constants.ALL_BOOK_FIELDS)
 
         resp = self.__req(
             self.mirror.lookup, ids=",".join(ids), fields=",".join(fields)
@@ -143,8 +143,8 @@ class Library(object):
             # TODO: add test case for this and see if i can .json() afterwards
             raise requests.HTTPError(400)
 
-        for book_data, _id in zip(resp, ids):
-            assert book_data["id"] == _id
+        for book_data in resp:
+            assert book_data["id"] in ids,"Invalid ids returned"
             yield Book(**book_data)
 
     def __req(self, endpoint, **kwargs):

--- a/pylibgen/pylibgen.py
+++ b/pylibgen/pylibgen.py
@@ -132,7 +132,7 @@ class Library(object):
         if "id" not in fields:
             fields.append("id")
         if "*" in fields:
-            fields = list(**constants.ALL_BOOK_FIELDS)
+            fields = list(constants.ALL_BOOK_FIELDS)
 
         resp = self.__req(
             self.mirror.lookup, ids=",".join(ids), fields=",".join(fields)

--- a/pylibgen/pylibgen.py
+++ b/pylibgen/pylibgen.py
@@ -144,7 +144,7 @@ class Library(object):
             raise requests.HTTPError(400)
 
         for book_data in resp:
-            assert book_data["id"] in ids,"Invalid ids returned"
+            assert book_data["id"] in ids, "Invalid ids returned"
             yield Book(**book_data)
 
     def __req(self, endpoint, **kwargs):


### PR DESCRIPTION
So i was trying out the code and found that some times lookup doesnt necessarily return the ids in the same order so I slightly changed the statement to accomadate that and also the option to include all fields in fields option of lookup was wrong so fixed that. 

Let me know if there are any changes to make 